### PR TITLE
Fix ci.yml cogserver dependency error

### DIFF
--- a/attention/CMakeLists.txt
+++ b/attention/CMakeLists.txt
@@ -88,7 +88,7 @@ ENDIF (ATOMSPACE_FOUND)
 # Check for existance of various required, optional packages.
 
 # CogServer
-FIND_PACKAGE(CogServer)
+FIND_PACKAGE(CogServer 0.1.4 CONFIG REQUIRED)
 IF (COGSERVER_FOUND)
 	MESSAGE(STATUS "CogServer found.")
 	ADD_DEFINITIONS(-DHAVE_COGSERVER)


### PR DESCRIPTION
Update CMake to find CogServer using its config file to fix CI build failures.

The previous `FIND_PACKAGE(CogServer)` implicitly looked for a `FindCogServer.cmake` module, which was not available. This change explicitly tells CMake to use `CogServer`'s provided `CogServerConfig.cmake` file, resolving the "CogServer missing" error during the CI build.

---
<a href="https://cursor.com/background-agent?bcId=bc-871951fc-c91b-430e-b96e-52b33a13db7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-871951fc-c91b-430e-b96e-52b33a13db7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

